### PR TITLE
non blocking when add log when producer are faster than log consumers

### DIFF
--- a/thinkingdata/consumer_log.go
+++ b/thinkingdata/consumer_log.go
@@ -81,7 +81,11 @@ func (c *LogConsumer) Add(d Data) error {
 		return err
 	}
 
-	c.ch <- string(bdata)
+	select {
+	case c.ch <- string(bdata):
+	default:
+		return errors.New("ta logger channel full")
+	}
 	return nil
 }
 


### PR DESCRIPTION
某些时候可能生产者在短时间内产生日志速度很快从而导致了log通道堆积满ChannelSize，此时若TA日志使用阻塞等待写的情况下会导致主程序逻辑阻塞，很多场景下日志报错而不阻塞主程序运行的策略可能更合适。